### PR TITLE
Prepare android backend

### DIFF
--- a/dashel/dashel-posix.cpp
+++ b/dashel/dashel-posix.cpp
@@ -310,7 +310,8 @@ namespace Dashel
 	SelectableStream::SelectableStream(const string& protocolName) : 
 		Stream(protocolName),
 		fd(-1),
-		writeOnly(false)
+		writeOnly(false),
+		pollEvent(POLLIN)
 	{
 		
 	}
@@ -1141,7 +1142,7 @@ namespace Dashel
 				pollFdsArray[i].fd = stream->fd;
 				pollFdsArray[i].events = 0;
 				if ((!stream->failed()) && (!stream->writeOnly))
-					pollFdsArray[i].events |= POLLIN;
+					pollFdsArray[i].events |= stream->pollEvent;
 				
 				i++;
 			}
@@ -1218,7 +1219,7 @@ namespace Dashel
 					
 					closeStream(stream);
 				}
-				else if (pollFdsArray[i].revents & POLLIN)
+				else if (pollFdsArray[i].revents & stream->pollEvent)
 				{
 					//std::cerr << "POLLIN" << std::endl;
 					wasActivity = true;

--- a/dashel/dashel-posix.h
+++ b/dashel/dashel-posix.h
@@ -51,6 +51,7 @@ namespace Dashel
 	protected:
 		int fd; //!< associated file descriptor
 		bool writeOnly;	//!< true if we can only write on this stream
+		short pollEvent; //!< the poll event we must react to
 		friend class Hub;
 	
 	public:


### PR DESCRIPTION
Allow to specify a poll event, so derived class can
change it to something elsa than POLLIN.
The android plugin needs it in order to access usb.
