### PR TITLE
RPM and shared lib improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ else (WIN32)
 endif (WIN32)
 
 add_library(dashel ${DASHEL_SOURCES})
+target_link_libraries(dashel ${EXTRA_LIBS})
 
 set(LIB_INSTALL_DIR lib CACHE FILEPATH "Where to install libraries")
 set(LIB_VERSION_MAJOR 1) # Must be bumped for incompatible ABI changes

--- a/rpm/dashel.spec
+++ b/rpm/dashel.spec
@@ -27,7 +27,7 @@ Version:        %{source_major}.%{source_minor}.%{source_patch}
 # release version (i.e. the "Version:" line above refers to a future
 # source release version), then set the number to 0.0. Otherwise, leave the
 # the number unchanged. It will get bumped when you run rpmdev-bumpspec.
-Release:        8%{?snapshot}%{?dist}
+Release:        9%{?snapshot}%{?dist}
 
 Summary:        A C++ cross-platform data stream helper encapsulation library
 
@@ -118,6 +118,10 @@ make install DESTDIR=$RPM_BUILD_ROOT
 
 
 %changelog
+* Mon May 05 2014 Dean Brettle <dean@brettle.com> - 1.0.7-9.20140505git8fb0d53
+- Added EXTRA_LIBS to dashel's target_link_libraries so that it will link to
+  libudev automatically.
+
 * Mon May 05 2014 Dean Brettle <dean@brettle.com> - 1.0.7-8.20140505git8fb0d53
 - Changed systemd-devel to libudev-devel in BuildRequires to accomodate
   OpenSUSE.


### PR DESCRIPTION
These changes:
1. allow dashel packages for the latest Fedora and OpenSUSE to be built on the OpenSUSE build server. 2. make the dashel shared lib dynamically link to EXTRA_LIBS (e.g. libudev.so) which should mean that programs which link with dashel won't also need to link with EXTRA_LIBS (unless they access those libs directly). I've tested this on Fedora, and am pretty confident that it will work on other Linux distros, but don't know about (and can't test) on Win32 and Apple.
