### PR TITLE
Fix CMP0042 warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ else (WIN32)
 		mark_as_advanced(IOKIT_LIBRARY)
 		find_library(POLL_LIBRARY poll)
 		set(EXTRA_LIBS ${COREFOUNDATION_LIBRARY} ${IOKIT_LIBRARY} ${POLL_LIBRARY})
+		set(CMAKE_MACOSX_RPATH ON) # Solve the CMP0042 warning
 	else (APPLE)
 		if (UDEV_FOUND)
 			include_directories(${UDEV_INCLUDE_DIR})


### PR DESCRIPTION
When compiling dashel from Mac OS X 10.11.5 with CMake 3.1.2, I get the following warning:

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   dashel

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning:
  Manually-specified variables were not used by the project:

    MACOSX_RPATH
```

From `cmake-policy --help-policy CMP0042`:

> CMake version 3.1.3 warns when the policy is not set and uses OLD behavior.

cf. http://stackoverflow.com/questions/31561309/cmake-warnings-under-os-x-macosx-rpath-is-not-specified-for-the-following-targe
