### PR TITLE
fixed #16 Improper condition for iPhone

### DIFF
--- a/dashel/dashel-posix.cpp
+++ b/dashel/dashel-posix.cpp
@@ -74,7 +74,7 @@
 #ifdef MACOSX
 	#include <CoreFoundation/CoreFoundation.h>
 	#include "TargetConditionals.h"
-	#ifndef TARGET_OS_IPHONE
+	#if TARGET_OS_IPHONE == 0
 		#include <IOKit/IOKitLib.h>
 		#include <IOKit/serial/IOSerialKeys.h>
 	#endif
@@ -134,7 +134,7 @@ namespace Dashel
 		
 
 
-#if defined MACOSX && !defined TARGET_OS_IPHONE
+#if defined MACOSX && TARGET_OS_IPHONE == 0
 		// use IOKit to enumerates devices
 		
 		// get a matching dictionary to specify which IOService class we're interested in

--- a/examples/dws.cpp
+++ b/examples/dws.cpp
@@ -89,7 +89,7 @@ public:
 		vector<string> requestParts(split(request, "\n\r\t "));
 		
 		// only support GET
-		if ((requestParts.size() < 2) or requestParts[0] != "GET")
+		if ((requestParts.size() < 2) || requestParts[0] != "GET")
 		{
 			cerr << stream << " Unsupported HTTP request" << request << endl;
 			sendString(stream, "HTTP/1.0 403\r\n\r\n");


### PR DESCRIPTION
Fixed issue #16 by testing value of `TARGET_OS_IPHONE`, which is always defined. Port enumeration on MacOS works again.

Also remove ISO646 "or" keyword with "||" in dws example.