### PR TITLE
retrieve port number when dynamically allocated

### DIFF
--- a/dashel/dashel-posix.cpp
+++ b/dashel/dashel-posix.cpp
@@ -588,6 +588,18 @@ namespace Dashel
 			addr.sin_addr.s_addr = htonl(bindAddress.address);
 			if (::bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 				throw DashelException(DashelException::ConnectionFailed, errno, "Cannot bind socket to port, probably the port is already in use.");
+
+			// retrieve port number, if a dynamic one was requested
+			if (bindAddress.port == 0)
+			{
+				socklen_t sizeof_addr(sizeof(addr));
+				if (getsockname(fd, (struct sockaddr *)&addr, &sizeof_addr) != 0)
+				throw DashelException(DashelException::ConnectionFailed, errno, "Cannot retrieve socket port assignment.");
+				target.erase("port");
+				ostringstream portnum;
+				portnum << ntohs(addr.sin_port);
+				target.addParam("port", portnum.str().c_str(), true);
+			}
 			
 			// Listen on socket, backlog is sort of arbitrary.
 			if(listen(fd, 16) < 0)
@@ -635,6 +647,18 @@ namespace Dashel
 				addr.sin_addr.s_addr = htonl(bindAddress.address);
 				if (::bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0)
 					throw DashelException(DashelException::ConnectionFailed, errno, "Cannot bind socket to port, probably the port is already in use.");
+
+				// retrieve port number, if a dynamic one was requested
+				if (bindAddress.port == 0)
+				{
+					socklen_t sizeof_addr(sizeof(addr));
+					if (getsockname(fd, (struct sockaddr *)&addr, &sizeof_addr) != 0)
+						throw DashelException(DashelException::ConnectionFailed, errno, "Cannot retrieve socket port assignment.");
+					target.erase("port");
+					ostringstream portnum;
+					portnum << ntohs(addr.sin_port);
+					target.addParam("port", portnum.str().c_str(), true);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
SocketServerStream and UDPSocketStream streams listen to an (address, port) pair. If the port is 0, then the operating system will dynamically allocate an ephemeral port.

This patch retrieves the port chosen by the operating system and modifies the ParameterSet for the stream to reflect the new port. Client code can learn which port was selected for stream `stream` by reading

```
stream->getTargetParameter("port")
```

Note that this code could be factored.
