### PR TITLE
Jenkinsfile for building, testing, packaging Dashel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,91 @@
+#!groovy
+
+// Jenkinsfile for compiling, testing, and packaging the Dashel libraries.
+// Requires CMake plugin from https://github.com/davidjsherman/aseba-jenkins.git in global library.
+
+pipeline {
+	agent label:'' // use any available Jenkins agent
+	stages {
+		stage('Prepare') {
+			steps {
+				dir('dashel') {
+					checkout scm
+				}
+				stash includes: 'dashel/**', excludes: '.git', name: 'source'
+			}
+		}
+		stage('Compile') {
+			steps {
+				parallel (
+					"debian" : {
+						node('debian') {
+							unstash 'source'
+							CMake([sourceDir: '$workDir/dashel', label: 'debian'])
+							stash includes: 'dist/**', name: 'dist-debian'
+							stash includes: 'build/**', name: 'build-debian'
+						}
+					},
+					"macos" : {
+						node('macos') {
+							unstash 'source'
+							CMake([sourceDir: '$workDir/dashel', label: 'macos'])
+							stash includes: 'dist/**', name: 'dist-macos'
+						}
+					},
+					"windows" : {
+						node('windows') {
+							unstash 'source'
+							CMake([sourceDir: '$workDir/dashel', label: 'windows'])
+							stash includes: 'dist/**', name: 'dist-windows'
+						}
+					}
+				)
+			}
+		}
+		stage('Test') {
+			steps {
+				node('debian') {
+					unstash 'build-debian'
+					dir('build/debian') {
+						sh 'LANG=C ctest'
+					}
+				}
+			}
+		}
+		stage('Package') {
+			steps {
+				parallel (
+					"debian" : {
+						node('debian') {
+							unstash 'dist-debian'
+							unstash 'source'
+							dir('dashel') {
+								sh 'which debuild && debuild -i -us -uc -b'
+							}
+							sh 'mv libdashel*.deb libdashel*.changes libdashel*.build dist/debian/'
+							stash includes: 'dist/**', name: 'dist-debian'
+						}
+					}
+				)
+			}
+		}
+		stage('Archive') {
+			steps {
+				script {
+					// Can't use collectEntries yet [JENKINS-26481]
+					def p = [:]
+					for (x in ['debian','macos','windows']) {
+						def label = x
+						p[label] = {
+							node(label) {
+								unstash 'dist-' + label
+								archiveArtifacts artifacts: 'dist/**', fingerprint: true, onlyIfSuccessful: true
+							}
+						}
+					}
+					parallel p;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This Jenkinsfile allows Dashel to be added as a multi branch project on any Jenkins platform whose build agents meet the prerequisites. Its goal is to automate testing of branches and pull requests in a development environment.

- [x] Check out and build each branch in a separate workspace (cmake, make, make install)
- [x] Run any tests (ctest)
- [x] If on a Debian node, build .deb package
- [x] Archive artifacts on the Jenkins server
- [x] Run [parallel steps across operating systems](https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Parallelism#testing-across-operating-systems)
- [ ] Upload artifacts to a web site using [credentials binding](https://jenkins.io/doc/pipeline/steps/credentials-binding/)

*Prerequisites*: [Jenkins Pipeline Model Definition](https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Getting-Started) plugin, [aseba-jenkins global library](https://github.com/davidjsherman/aseba-jenkins).

See [buildfarm](https://github.com/davidjsherman/aseba-jenkins/tree/master/resources/buildfarm) in davidjsherman/[aseba-jenkins](https://github.com/davidjsherman/aseba-jenkins) for tools and instructions for configuring Jenkins build agents that can run this Jenkinsfile, either on an existing platform or in a Jenkins Docker container.

See [Creating an Aseba project in Jenkins](https://github.com/davidjsherman/aseba-jenkins/tree/master/resources/buildfarm#creating-an-aseba-project-in-jenkins) for brief instructions about configuring a multi branch project for Dashel, that can also update badges on GitHub pull requests.