### PR TITLE
Catch exceptions by lvalue reference

### DIFF
--- a/dashel/dashel-posix.cpp
+++ b/dashel/dashel-posix.cpp
@@ -1276,7 +1276,7 @@ namespace Dashel
 					{
 						stream->fail(DashelException::SyncError, 0, "Error on stream during poll.");
 					}
-					catch (DashelException e)
+					catch (DashelException &e)
 					{
 						assert(e.stream);
 					}
@@ -1285,7 +1285,7 @@ namespace Dashel
 					{
 						connectionClosed(stream, true);
 					}
-					catch (DashelException e)
+					catch (DashelException &e)
 					{
 						assert(e.stream);
 					}
@@ -1301,7 +1301,7 @@ namespace Dashel
 					{
 						connectionClosed(stream, false);
 					}
-					catch (DashelException e)
+					catch (DashelException &e)
 					{
 						assert(e.stream);
 					}
@@ -1356,7 +1356,7 @@ namespace Dashel
 								//std::cerr << "incoming data" << std::endl;
 							}
 						}
-						catch (DashelException e)
+						catch (DashelException &e)
 						{
 							//std::cerr << "exception on POLLIN" << std::endl;
 							assert(e.stream);
@@ -1394,7 +1394,7 @@ namespace Dashel
 					{
 						connectionClosed(stream, true);
 					}
-					catch (DashelException e)
+					catch (DashelException &e)
 					{
 						assert(e.stream);
 					}

--- a/examples/chat.cpp
+++ b/examples/chat.cpp
@@ -74,7 +74,7 @@ class ChatClient: public Hub
 {
 public:
 	ChatClient(string remoteTarget, const string& nick) :
-		nick(nick), inputStream(0)
+		inputStream(0), nick(nick)
 	{
 		remoteTarget += ";port=8765";
 		inputStream = connect("stdin:");

--- a/examples/chat.cpp
+++ b/examples/chat.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 			server.run();
 		}
 	}
-	catch(DashelException e)
+	catch(DashelException &e)
 	{
 		std::cerr << e.what() << std::endl;
 	}

--- a/examples/dws.cpp
+++ b/examples/dws.cpp
@@ -141,7 +141,7 @@ int main(int argc, char* argv[])
 		WebServer webServer(argc > 1 ? argv[1] : "8080");
 		webServer.run();
 	}
-	catch(DashelException e)
+	catch(DashelException &e)
 	{
 		std::cerr << e.what() << std::endl;
 	}

--- a/examples/microterm.cpp
+++ b/examples/microterm.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
 		
 		microTerm.run();
 	}
-	catch (DashelException e)
+	catch (DashelException &e)
 	{
 		std::cerr << e.what() << std::endl;
 	}

--- a/examples/udp.cpp
+++ b/examples/udp.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
 			PingServer().run();
 		}
 	}
-	catch(DashelException e)
+	catch(DashelException &e)
 	{
 		std::cerr << e.what() << std::endl;
 	}


### PR DESCRIPTION
[CERT ERR61-CPP](https://sonarcloud.io/organizations/davidjsherman-github/rules#q=ERR61-CPP) suggested by SonarQube

>When exception classes are caught by value, rather than by reference, slicing occurs, yielding an instance of the exception's base class, rather than the potentially more specific exception class that was actually thrown. This means that only the base class' functions will be available; any additional data or functionality that is offered by the extended class will not be accessible. Therefore exception classes should always be caught by reference.