### PR TITLE
Make the build reproducible

### DIFF
--- a/dashelConfig.cmake.in
+++ b/dashelConfig.cmake.in
@@ -42,8 +42,8 @@ else (WIN32)
 endif (WIN32)
 
 # Standard search
-find_path(dashel_INCLUDE_DIRS dashel/dashel.h @PROJECT_SOURCE_DIR@ CMAKE_FIND_ROOT_PATH_BOTH)
-find_library(dashel_LIBRARY dashel @PROJECT_BINARY_DIR@ CMAKE_FIND_ROOT_PATH_BOTH)
+find_path(dashel_INCLUDE_DIRS dashel/dashel.h CMAKE_FIND_ROOT_PATH_BOTH)
+find_library(dashel_LIBRARY dashel CMAKE_FIND_ROOT_PATH_BOTH)
 set(dashel_LIBRARIES ${dashel_LIBRARY} ${EXTRA_LIBS})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(dashel DEFAULT_MSG dashel_LIBRARIES dashel_INCLUDE_DIRS)


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed that dashel could not be built reproducibly. This is due to it embedding the absolute build path.

This was originally filed in Debian as #890311 [1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/890311

Signed-off-by: Chris Lamb <lamby@debian.org>